### PR TITLE
delete_chats_of_all_exited_groups method was created in groups.py

### DIFF
--- a/tithiwa/constants.py
+++ b/tithiwa/constants.py
@@ -51,6 +51,7 @@ class SELECTORS(object):
     GROUPS__REMOVE_ADMIN = (By.CSS_SELECTOR, 'div[title="Dismiss as admin"]')
     GROUPS__REMOVE = (By.CSS_SELECTOR, 'div[title="Remove"]')
     GROUPS__EXIT_FROM_GROUP = (By.CSS_SELECTOR, 'div[title="Exit group"]')
+    GROUPS__DELETE_GROUP = (By.CSS_SELECTOR, 'div[title="Delete group"]')
     # GROUPS__EXIT_DIALOG_BOX_EXIT_BUTTON = (By.CSS_SELECTOR, 'div[class^="overlay"] div[role="button"]:nth-child(2)')
     # GROUPS__NO_LONGER_A_PARTICIPANT = (By.CSS_SELECTOR, '._3ge3i')
     GROUPS__NAME_IN_CHATS = (By.CSS_SELECTOR, '#side div[aria-label^="Chat list"] div > span[dir="auto"][title]')

--- a/tithiwa/group.py
+++ b/tithiwa/group.py
@@ -260,6 +260,46 @@ class Group(Chatroom, WaObject):
             if _shouldoutput[1] and DEFAULT_SHOULD_OUTPUT:
                 print(f'{STRINGS.CHECK_CHAR} You already joined it. Done')
 
+    def delete_chats_of_all_exited_groups(self):
+        self._wait_for_presence_of_an_element(SELECTORS.GROUPS__NAME_IN_CHATS)
+        self._wait_for_an_element_to_be_clickable(SELECTORS.MAIN_SEARCH_BAR).click()
+        preactive = None
+        self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+        curractive = self.browser.switch_to.active_element
+        pregroupname = None
+        count = 0
+        while curractive != preactive:
+            footertext = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__FOOTER).get_attribute('innerText')
+            if footertext == r"You can't send messages to this group because you're no longer a participant.":
+                self._wait_for_an_element_to_be_clickable(SELECTORS.CHATROOM__NAME).click()
+                self._wait_for_an_element_to_be_clickable(SELECTORS.GROUPS__DELETE_GROUP).click()
+                self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
+                self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()
+                self._close_chat_info()
+                self._close_info()
+
+                self._wait_for_presence_of_an_element(SELECTORS.GROUPS__NAME_IN_CHATS)
+                self._wait_for_an_element_to_be_clickable(SELECTORS.MAIN_SEARCH_BAR).click()
+                preactive = None
+                if count != 0:
+                    for i in range(count):
+                        self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+                    count -= 1
+                else:
+                    self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+                curractive = self.browser.switch_to.active_element
+                pregroupname = None
+                continue
+            
+            preactive = curractive
+            pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
+            curractive.send_keys(Keys.ARROW_DOWN)
+            curractive = self.browser.switch_to.active_element
+            sleep(0.5)
+            count += 1
+
+
+    
     # create_group('yeh', ["Navpreet Devpuri"])
 
 # print(scrape_members_from_group("PROGRAMMING"))

--- a/tithiwa/group.py
+++ b/tithiwa/group.py
@@ -1,6 +1,5 @@
 __all__ = ["Group"]
 
-from time import sleep
 from .constants import *
 from .chatroom import Chatroom
 from .waobject import WaObject
@@ -295,7 +294,6 @@ class Group(Chatroom, WaObject):
             pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
             curractive.send_keys(Keys.ARROW_DOWN)
             curractive = self.browser.switch_to.active_element
-            sleep(0.5)
             count += 1
 
 


### PR DESCRIPTION
There was no way to differentiate groups and normal chat, therefore, I was forced to scroll through entire list of contacts, where it checks for the message "You can't send messages to this group because you're no longer a participant", if message is found then it deletes the group. Now, if we allow the program to run freely without any time.sleep() it scrolls through entire list of contact without finding any match, _wait_for_presence_of_an_element was also not working so to reduce its speed I had used sleep(0.5).
There was another problem, when delete chat is successful, program losts track of which contact or group should be clicked next. So, we have to scroll from top again, But since we have already checked top few contacts, I added count variable which contains number of chats checked so far, so that it quickly scrolls through those number of chats quickly without waiting for 0.5seconds, and then continues it search again.

Constants file didn't contain any delete group button selector, so I have added GROUPS__DELETE_GROUP selector.