### PR TITLE
clear_all_chats method was added in Tithiwa class

### DIFF
--- a/tithiwa/chatroom.py
+++ b/tithiwa/chatroom.py
@@ -48,7 +48,28 @@ class Chatroom(WaObject):
             if given_time == time_now:
                 self.send_message_to_multiple_chats(nameornumberlist, message)
                 break
-
+                
+    def clear_all_chats(self):
+        self._wait_for_presence_of_an_element(SELECTORS.GROUPS__NAME_IN_CHATS)
+        self._wait_for_an_element_to_be_clickable(SELECTORS.MAIN_SEARCH_BAR).click()
+        preactive = None
+        self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+        curractive = self.browser.switch_to.active_element
+        pregroupname = None
+        while curractive != preactive:
+            self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__OPTIONS)
+            
+            for i in range(3):
+                self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+            self.browser.switch_to.active_element.send_keys(Keys.ENTER)
+            self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
+            self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()      
+            
+            preactive = curractive
+            pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
+            curractive.send_keys(Keys.ARROW_DOWN)
+            curractive = self.browser.switch_to.active_element
+            
     def _open_chat_info(self):
         self._wait_for_an_element_to_be_clickable(SELECTORS.CHATROOM__NAME).click()
 

--- a/tithiwa/chatroom.py
+++ b/tithiwa/chatroom.py
@@ -65,6 +65,8 @@ class Chatroom(WaObject):
             self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
             self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()      
             
+            self._close_info()
+            
             preactive = curractive
             pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
             curractive.send_keys(Keys.ARROW_DOWN)

--- a/tithiwa/chatroom.py
+++ b/tithiwa/chatroom.py
@@ -58,10 +58,7 @@ class Chatroom(WaObject):
         pregroupname = None
         while curractive != preactive:
             self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__OPTIONS)
-            
-            for i in range(3):
-                self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
-            self.browser.switch_to.active_element.send_keys(Keys.ENTER)
+            self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__CLEAR_MESSAGES).click()
             self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
             self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()      
             

--- a/tithiwa/constants.py
+++ b/tithiwa/constants.py
@@ -35,7 +35,7 @@ class SELECTORS(object):
     CHATROOM__INFO_NUMBER = (By.CSS_SELECTOR, 'span[class*="invisible-space"][dir="auto"] span[class*="_"]')
     CHATROOM__CLOSE_INFO = (
         By.CSS_SELECTOR, 'div[style="height: 100%; transform: translateX(0%);"] span[data-testid="x"]')
-    CHATROOM__OPTIONS = (By.CSS_SELECTOR, '[data-testid="menu"]')
+    CHATROOM__OPTIONS = (By.CSS_SELECTOR, '#main span[data-testid="menu"]')
     CHATROOM__INFO_DELETE_CHAT = (By.CSS_SELECTOR, '._1OwwW ._3oTCZ[title="Delete chat"]')
     CHATROOM__DELETE_CHAT = (By.CSS_SELECTOR, 'li div[title="Delete chat"]')
     CHATROOM__FOOTER = (By.CSS_SELECTOR, 'footer')

--- a/tithiwa/constants.py
+++ b/tithiwa/constants.py
@@ -38,6 +38,7 @@ class SELECTORS(object):
     CHATROOM__OPTIONS = (By.CSS_SELECTOR, '#main span[data-testid="menu"]')
     CHATROOM__INFO_DELETE_CHAT = (By.CSS_SELECTOR, '._1OwwW ._3oTCZ[title="Delete chat"]')
     CHATROOM__DELETE_CHAT = (By.CSS_SELECTOR, 'li div[title="Delete chat"]')
+    CHATROOM__CLEAR_MESSAGES = (By.CSS_SELECTOR, 'li div[aria-label="Clear messages"]')
     CHATROOM__FOOTER = (By.CSS_SELECTOR, 'footer')
     CONTACTS__NAME_IN_CHATS = (By.CSS_SELECTOR, '#side div[aria-label^="Chat list"] div span span[dir="auto"][title]')
     GROUPS__MEMBERS_SEARCH_ICON = (By.CSS_SELECTOR, 'div[role="button"] span[data-testid="search"]')

--- a/tithiwa/main.py
+++ b/tithiwa/main.py
@@ -4,10 +4,35 @@ from .session import Session
 from .settings import Settings
 from .group import Group
 from .contact import Contact
+from time import sleep
+from .constants import *
+from selenium.webdriver.common.keys import Keys
 
 class Tithiwa(Session, Settings, Group, Contact):
     def __init__(self, browser=None):
         super().__init__(browser)
+
+    def clear_all_chats(self):
+        self._wait_for_presence_of_an_element(SELECTORS.GROUPS__NAME_IN_CHATS)
+        self._wait_for_an_element_to_be_clickable(SELECTORS.MAIN_SEARCH_BAR).click()
+        preactive = None
+        self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+        curractive = self.browser.switch_to.active_element
+        pregroupname = None
+        while curractive != preactive:
+            sleep(0.5)
+            self.browser.find_element_by_xpath("/html/body/div[1]/div[1]/div[1]/div[4]/div[1]/header/div[3]/div/div[2]/div/div/span").click()
+            for i in range(3):
+                self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
+            self.browser.switch_to.active_element.send_keys(Keys.ENTER)
+            self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
+            self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()      
+            
+            preactive = curractive
+            pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
+            curractive.send_keys(Keys.ARROW_DOWN)
+            curractive = self.browser.switch_to.active_element
+
 
     # def __del__(self):
     #     self.browser.quit()

--- a/tithiwa/main.py
+++ b/tithiwa/main.py
@@ -4,7 +4,6 @@ from .session import Session
 from .settings import Settings
 from .group import Group
 from .contact import Contact
-from time import sleep
 from .constants import *
 from selenium.webdriver.common.keys import Keys
 
@@ -20,8 +19,13 @@ class Tithiwa(Session, Settings, Group, Contact):
         curractive = self.browser.switch_to.active_element
         pregroupname = None
         while curractive != preactive:
-            sleep(0.5)
-            self.browser.find_element_by_xpath("/html/body/div[1]/div[1]/div[1]/div[4]/div[1]/header/div[3]/div/div[2]/div/div/span").click()
+            while True:
+                try:
+                    self.browser.find_element_by_xpath("/html/body/div[1]/div[1]/div[1]/div[4]/div[1]/header/div[3]/div/div[2]/div/div/span").click()
+                    break
+                except:
+                    pass
+            
             for i in range(3):
                 self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
             self.browser.switch_to.active_element.send_keys(Keys.ENTER)

--- a/tithiwa/main.py
+++ b/tithiwa/main.py
@@ -11,32 +11,5 @@ class Tithiwa(Session, Settings, Group, Contact):
     def __init__(self, browser=None):
         super().__init__(browser)
 
-    def clear_all_chats(self):
-        self._wait_for_presence_of_an_element(SELECTORS.GROUPS__NAME_IN_CHATS)
-        self._wait_for_an_element_to_be_clickable(SELECTORS.MAIN_SEARCH_BAR).click()
-        preactive = None
-        self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
-        curractive = self.browser.switch_to.active_element
-        pregroupname = None
-        while curractive != preactive:
-            while True:
-                try:
-                    self.browser.find_element_by_xpath("/html/body/div[1]/div[1]/div[1]/div[4]/div[1]/header/div[3]/div/div[2]/div/div/span").click()
-                    break
-                except:
-                    pass
-            
-            for i in range(3):
-                self.browser.switch_to.active_element.send_keys(Keys.ARROW_DOWN)
-            self.browser.switch_to.active_element.send_keys(Keys.ENTER)
-            self._wait_for_presence_of_an_element(SELECTORS.OVERLAY)
-            self._wait_for_an_element_to_be_clickable(SELECTORS.OVERLAY_OK).click()      
-            
-            preactive = curractive
-            pregroupname = self._wait_for_presence_of_an_element(SELECTORS.CHATROOM__NAME)
-            curractive.send_keys(Keys.ARROW_DOWN)
-            curractive = self.browser.switch_to.active_element
-
-
     # def __del__(self):
     #     self.browser.quit()

--- a/tithiwa/session.py
+++ b/tithiwa/session.py
@@ -110,7 +110,7 @@ class Session(WaObject):
             subprocess.Popen(["xdg-open", path])
 
     def _is_logged_in(self):
-         if "WAToken1" not in self.browser.execute_script(
+        if "WAToken1" not in self.browser.execute_script(
                 "return window.localStorage;"):
             return False
         else:


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/44338274/138740483-1a763172-0552-477d-9807-b1e8e5d14e74.PNG)
Since whatsapp had two elements for menu with same class and Ids, I was forced to use full xpath instead of CSS selector for accessing the menu.  Then using arrow keys the program navigates to  "clear messages", and then uses ENTER key to clear chat.
Sometimes chat takes some time to load, and program returned error "element not found", to avoid that I tried using implicit wait - self.browser.implicitly_wait(3), but for some reason I still recieved error so atlast I used sleep(0.5). 